### PR TITLE
Auto install backend requirements when running manage.py

### DIFF
--- a/Backend/manage.py
+++ b/Backend/manage.py
@@ -1,7 +1,28 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 import os
+import subprocess
 import sys
+from pathlib import Path
+
+
+def _install_requirements() -> bool:
+    """Install backend requirements if the requirements file is present."""
+
+    requirements_path = Path(__file__).resolve().parent / "requirements.txt"
+    if not requirements_path.exists():
+        return False
+
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-r", str(requirements_path)]
+        )
+    except subprocess.CalledProcessError as error:  # pragma: no cover - setup helper
+        raise ImportError(
+            "Django is not installed and the automatic installation of requirements failed."
+        ) from error
+
+    return True
 
 
 def main() -> None:
@@ -9,10 +30,18 @@ def main() -> None:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
         from django.core.management import execute_from_command_line
-    except ImportError as exc:  # pragma: no cover - Django should be installed
-        raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and available on your PYTHONPATH environment variable?"
-        ) from exc
+    except ImportError:
+        if not _install_requirements():
+            raise ImportError(
+                "Couldn't import Django and no requirements.txt was found to install it from."
+            )
+
+        try:
+            from django.core.management import execute_from_command_line
+        except ImportError as exc:  # pragma: no cover - should now be installed
+            raise ImportError(
+                "Couldn't import Django even after installing Backend/requirements.txt."
+            ) from exc
     execute_from_command_line(sys.argv)
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ python Backend/manage.py migrate
 python Backend/manage.py runserver
 ```
 
+> **Tip:** `python Backend/manage.py runserver` will automatically install the dependencies listed in `Backend/requirements.txt` if they are missing, so you can jump straight into development with a single command.
+
 The UI is served at [http://localhost:8000](http://localhost:8000). Conversations are persisted to `db.sqlite3` inside the `Backend/` directory.
 
 ### 3. Configure a model (optional)


### PR DESCRIPTION
## Summary
- automatically install Backend/requirements.txt when Django is missing so runserver works out of the box
- document the automatic dependency installation in the README for easier setup

## Testing
- python Backend/manage.py check *(fails: pip cannot reach package index in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a153ffdc832c85e879531135e423