### PR TITLE
Configure email SMTP credentials and stabilize auth tests

### DIFF
--- a/Backend/app/tests/__init__.py
+++ b/Backend/app/tests/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+
+import django
+from django.core.management import call_command
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+call_command("migrate", run_syncdb=True, verbosity=0)

--- a/Backend/app/tests/test_auth.py
+++ b/Backend/app/tests/test_auth.py
@@ -25,6 +25,10 @@ class AuthViewTests(TestCase):
         self.assertEqual(data["user"]["username"], "alice")
         self.assertTrue(User.objects.filter(username="alice").exists())
 
+        created_user = User.objects.get(username="alice")
+        self.assertNotEqual(created_user.password, payload["password"])
+        self.assertTrue(created_user.check_password(payload["password"]))
+
         session_response = self.client.get(reverse("session_info"))
         self.assertEqual(session_response.status_code, 200)
         self.assertTrue(session_response.json().get("authenticated"))

--- a/Backend/config/admin_email.json
+++ b/Backend/config/admin_email.json
@@ -1,0 +1,9 @@
+{
+  "host": "smtp.gmail.com",
+  "port": 587,
+  "use_tls": true,
+  "email": "sammaretia@gmail.com",
+  "app_password": "xwhy rgdo iafh aefr",
+  "approver_email": "sammaretia@gmail.com",
+  "from_email": "sammaretia@gmail.com"
+}

--- a/Backend/pytest.ini
+++ b/Backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- bootstrap Django during pytest collection so auth tests can execute without errors
- extend registration test coverage to confirm password hashing and active session behaviour
- provide Gmail SMTP credentials via `config/admin_email.json` for admin notifications
- add a project-local `pytest.ini` so pytest resolves Django modules correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ea5a0980832c91c3695f4fe7f241