### PR TITLE
Add self-service password reset flow

### DIFF
--- a/Backend/app/urls.py
+++ b/Backend/app/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("auth/session", views.session_info, name="session_info"),
     path("auth/register", views.register, name="register"),
     path("auth/login", views.login, name="login"),
+    path("auth/reset-password", views.reset_password, name="reset_password"),
     path("auth/logout", views.logout, name="logout"),
     path("auth/become-admin", views.request_admin, name="request_admin"),
     path("conversations", views.list_conversations, name="list_conversations"),

--- a/Frontend/static/style.css
+++ b/Frontend/static/style.css
@@ -414,6 +414,20 @@ textarea:focus {
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
+.btn.link {
+  background: none;
+  border: none;
+  padding: 0;
+  box-shadow: none;
+  color: var(--accent);
+  justify-content: flex-start;
+}
+
+.btn.link:hover:not(:disabled) {
+  transform: none;
+  text-decoration: underline;
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -499,6 +513,12 @@ textarea:focus {
   border: 1px solid var(--border);
   padding: 0.65rem 0.75rem;
   background: rgba(15, 23, 42, 0.4);
+}
+
+.auth-help-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0;
 }
 
 .tab-list {

--- a/Frontend/templates/index.html
+++ b/Frontend/templates/index.html
@@ -160,8 +160,21 @@
               <span>Password</span>
               <input type="password" id="auth-password" autocomplete="current-password" required />
             </label>
+            <label id="auth-confirm-wrapper" class="hidden">
+              <span>Confirm password</span>
+              <input
+                type="password"
+                id="auth-confirm-password"
+                autocomplete="new-password"
+              />
+            </label>
+            <p id="auth-help-text" class="auth-help-text hidden">
+              Enter your username or email along with a new password to reset your
+              access.
+            </p>
             <button type="submit" class="btn primary" id="auth-submit">Continue</button>
             <button type="button" class="btn secondary" id="auth-toggle-mode">Switch to register</button>
+            <button type="button" class="btn link" id="auth-forgot-password">Forgot password?</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a backend endpoint to reset user passwords with validation and coverage
- expose the reset route and expand frontend auth logic for reset, confirmation, and mode management
- refresh the auth modal UI with confirmation input, help text, styling, and a forgot-password trigger

## Testing
- pytest Backend

------
https://chatgpt.com/codex/tasks/task_e_68e33bda6a38832cb80f2bf97eb951a8